### PR TITLE
[Fix] StackViewBuilder AddArrangeSubviews로 변경

### DIFF
--- a/Sources/UIBuilder/View/StackViewBuilder.swift
+++ b/Sources/UIBuilder/View/StackViewBuilder.swift
@@ -15,7 +15,7 @@ public class StackViewBuilder: UIBuilder<UIStackView> {
         return self
     }
     
-    public func addArrangedSubviews(_ views: [UIView]) -> Self {
+    public func addArrangedSubviews(_ views: UIView...) -> Self {
         views.forEach { [weak self] in
             self?.view.addArrangedSubview($0)
         }

--- a/Sources/UIBuilder/View/StackViewBuilder.swift
+++ b/Sources/UIBuilder/View/StackViewBuilder.swift
@@ -15,8 +15,10 @@ public class StackViewBuilder: UIBuilder<UIStackView> {
         return self
     }
     
-    public func addArrangedSubview(_ view: UIView) -> Self {
-        self.view.addArrangedSubview(view)
+    public func addArrangedSubviews(_ views: [UIView]) -> Self {
+        views.forEach { [weak self] in
+            self?.view.addArrangedSubview($0)
+        }
         return self
     }
     

--- a/Sources/UIBuilder/View/StackViewBuilder.swift
+++ b/Sources/UIBuilder/View/StackViewBuilder.swift
@@ -15,10 +15,8 @@ public class StackViewBuilder: UIBuilder<UIStackView> {
         return self
     }
     
-    public func addArrangedSubviews(_ views: [UIView]) -> Self {
-        views.forEach { [weak self] in
-            self?.view.addArrangedSubview($0)
-        }
+    public func addArrangedSubview(_ view: UIView) -> Self {
+        self.view.addArrangedSubview(view)
         return self
     }
     


### PR DESCRIPTION
## 이슈 내용
이슈번호 :  #3 

StackViewBuilder에 SubViews로 넣는 프로퍼티가 제공되지 않아 생성자로 넣어주거나 Subview를 여러번 호출해야해서
가독성을 떨어트림

## 작업 내용
SetArrageSubViews 구현 대신 AddArrangeSubview를 AddArrangeSubviews로 변경