### PR TITLE
[Feat] LabelBuilder 기능 추가 구현

### DIFF
--- a/Sources/UIBuilder/View/LabelBuilder.swift
+++ b/Sources/UIBuilder/View/LabelBuilder.swift
@@ -82,6 +82,22 @@ public class LabelBuilder: UIBuilder<UILabel> {
         return self
     }
     
+    /// 부분 색상 강조
+    /// - Parameter Color : 강조할 색상
+    /// - Parameter pointText : 강조할 텍스트
+    public func setPointTextColor(_ pointText: String, color: UIColor) -> Self {
+        guard let content = view.text else { return self }
+        
+        let attributedStr = NSMutableAttributedString(string: content)
+        attributedStr.addAttribute(.foregroundColor,
+                                   value: color,
+                                   range: (content as NSString).range(of: pointText))
+        
+        self.view.attributedText = attributedStr
+
+        return self
+    }
+    
     public func setShadowColor(_ color: UIColor?) -> Self {
         view.shadowColor = color
         return self

--- a/Sources/UIBuilder/View/LabelBuilder.swift
+++ b/Sources/UIBuilder/View/LabelBuilder.swift
@@ -98,6 +98,23 @@ public class LabelBuilder: UIBuilder<UILabel> {
         return self
     }
     
+    public func setLineHeight(_ lineHeight: CGFloat) -> Self {
+        guard let text = view.text else { return self }
+            let style = NSMutableParagraphStyle()
+            style.maximumLineHeight = lineHeight
+            style.minimumLineHeight = lineHeight
+        
+            let attributes: [NSAttributedString.Key: Any] = [
+                .paragraphStyle: style,
+                .baselineOffset: (lineHeight - view.font.lineHeight) / 4
+            ]
+            
+            let attrString = NSAttributedString(string: text,
+                                                attributes: attributes)
+            view.attributedText = attrString
+        return self
+    }
+    
     public func setShadowColor(_ color: UIColor?) -> Self {
         view.shadowColor = color
         return self


### PR DESCRIPTION
## 이슈 내용
이슈 번호 : #5

레이블에서 부분 색상 변경을 통해 강조하는 기능 구현이 필요하나 UIBuilder에 해당 기능 구현이 안되어 있음

## 작업 내용

- setPointTextColor 구현
- setLineHeight 구현

### ✅Use
```swift
    private lazy var testLabel = LabelBuilder()
        .setText("텍스트 강조 기능 테스트\n다음줄\n2번째 줄")
        .setTextColor(.blue) 
        .setPointTextColor("강조", color: .red) // 🔧New
        .setLineHeight(30) // 🔧New
        .setFont(.systemFont(ofSize: 16))
        .addToSuperView(self.view)
        .setNumberOfLines(3)
        .build()
```

## 기타 스크린샷
![스크린샷 2023-11-22 오후 1 47 47](https://github.com/MightyCombine/UIBuilder/assets/61108853/466ac728-092e-40f6-873d-a701777da848)
<img src = "https://github.com/MightyCombine/UIBuilder/assets/61108853/e205a7b4-ec9a-4a9a-a537-6fa005b855c0" width = 300 >


